### PR TITLE
Sjekke audience på Azure-Tokens

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
-val dusseldorfVersion = "1.5.4.257334d"
+val dusseldorfVersion = "1.5.4.ae44e47"
 val ktorVersion = "1.5.4"
 val junitJupiterVersion = "5.7.2"
 val assertJVersion = "3.19.0"
@@ -9,7 +9,7 @@ val mockkVersion = "1.11.0"
 val mainClass = "no.nav.omsorgspenger.AppKt"
 
 plugins {
-    kotlin("jvm") version "1.5.0"
+    kotlin("jvm") version "1.5.10"
     id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -16,7 +16,7 @@
     "AZURE_GRUPPEMAPPING_RESOURCE_PATH": "azureGruppeMapping/prod.json",
     "OPEN_AM_JWKS_URI": "https://omsorgspenger-proxy.prod-fss-pub.nais.io/open-am/keys",
     "OPEN_AM_ISSUER": "https://isso.adeo.no:443/isso/oauth2",
-    "PDL_BASE_URL": "https://pdl-api.prod-fss-pub.nais.io/graphql",
+    "PDL_BASE_URL": "https://pdl-api.prod-fss-pub.nais.io",
     "PDL_SCOPES": "api://prod-fss.pdl.pdl-api/.default"
   }
 }

--- a/src/main/kotlin/no/nav/omsorgspenger/App.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/App.kt
@@ -84,7 +84,8 @@ fun Application.app() {
     val accessTokenClient = ClientSecretAccessTokenClient(
         clientId = azureConfig.property("client_id").getString(),
         clientSecret = azureConfig.property("client_secret").getString(),
-        tokenEndpoint = URI(azureConfig.property("token_endpoint").getString())
+        tokenEndpoint = URI(azureConfig.property("token_endpoint").getString()),
+        authenticationMode = ClientSecretAccessTokenClient.AuthenticationMode.POST
     )
 
     val pdlClient = PdlClient(

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -12,7 +12,9 @@ nav {
     azure_gruppemapping_resource_path = ${?AZURE_GRUPPEMAPPING_RESOURCE_PATH}
     auth {
         issuers = [{
+            type = "azure"
             alias = "azure-v2"
+            audience = ${?AZURE_APP_CLIENT_ID}
             jwks_uri = ${?AZURE_OPENID_CONFIG_JWKS_URI}
             issuer = ${?AZURE_OPENID_CONFIG_ISSUER}
         }, {

--- a/src/test/kotlin/no/nav/omsorgspenger/api/PersonTilgangApiTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/api/PersonTilgangApiTest.kt
@@ -157,6 +157,18 @@ internal class PersonTilgangApiTest(
     }
 
     @Test
+    fun `Gir 403 dersom token har feil audience`() {
+        with(testApplicationEngine) {
+            handleRequest(HttpMethod.Post, "/api/tilgang/personer") {
+                addHeader(HttpHeaders.ContentType, "application/json")
+                addHeader("Authorization", "Bearer ${gyldigToken(grupper = setOf("Beslutter"), audience = "any")}")
+            }.apply {
+                assertThat(response.status()).isEqualTo(HttpStatusCode.Forbidden)
+            }
+        }
+    }
+
+    @Test
     fun `Gir 403 dersom token ikke er utstedt til en personbruker`() {
         val tokenUtenPersonbrukerClaims = Azure.V2_0.generateJwt(
             clientId = "any",
@@ -245,11 +257,12 @@ internal class PersonTilgangApiTest(
 }
 
 internal fun gyldigToken(
-    grupper: Set<String>
+    grupper: Set<String>,
+    audience : String = "omsorgspenger-tilgangsstyring"
 ) = Azure.V2_0.generateJwt(
     clientId = "any",
     clientAuthenticationMode = Azure.ClientAuthenticationMode.CLIENT_SECRET,
-    audience = "any",
+    audience = audience,
     groups = grupper,
     overridingClaims = mapOf(
         "oid" to "any",

--- a/src/test/kotlin/no/nav/omsorgspenger/testutils/MockedEnvironment.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/testutils/MockedEnvironment.kt
@@ -25,6 +25,8 @@ internal class MockedEnvironment(
 
     init {
         appConfig["nav.auth.issuers.0.alias"] = "azure-v2"
+        appConfig["nav.auth.issuers.0.type"] = "azure"
+        appConfig["nav.auth.issuers.0.audience"] = "omsorgspenger-tilgangsstyring"
         appConfig["nav.auth.issuers.0.jwks_uri"] = wireMockServer.getAzureV2JwksUrl()
         appConfig["nav.auth.issuers.0.issuer"] = Azure.V2_0.getIssuer()
         appConfig["nav.auth.issuers.1.alias"] = "open-am"


### PR DESCRIPTION
Nå som vi veksler tokens før vi requester PDL må vi sitte med et token scopet til tilgangsstyring.
kun da får vi lov å veksle videre til PDL-token.

Dette er ordnet i consumerne av tilgangssttyring:
- navikt/omsorgspenger-sak/pull/44
- https://github.com/navikt/omsorgsdager/commit/c881f5c75f93e854402b968297d76ec4bf3f9e79
- navikt/omsorgspenger-rammemeldinger/pull/97
- k9-aarskvantum sender kun OpenAm-Tokens som har en annen flyt via omsorgspenger-proxy