### PR TITLE
Erstatter ubrukt bostedsadresse med folkeregisteridentifikator.

### DIFF
--- a/src/main/kotlin/no/nav/omsorgspenger/pdl/HentPerson.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/pdl/HentPerson.kt
@@ -10,9 +10,9 @@ data class Data(
 )
 
 data class HentPerson(
-    val bostedsadresse: List<Bostedsadresse>
+    val folkeregisteridentifikator: List<Folkeregisteridentifikator>
 )
 
-data class Bostedsadresse(
-    val coAdressenavn: String?
+data class Folkeregisteridentifikator(
+    val identifikasjonsnummer: String
 )

--- a/src/main/resources/pdl/hentPerson.graphql
+++ b/src/main/resources/pdl/hentPerson.graphql
@@ -1,7 +1,7 @@
 query($ident: ID!){
     hentPerson(ident: $ident) {
-        bostedsadresse {
-            coAdressenavn
+        folkeregisteridentifikator {
+            identifikasjonsnummer
         }
     }
 }

--- a/src/test/kotlin/no/nav/omsorgspenger/testutils/mocks/PdlApiMockHentPerson.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/testutils/mocks/PdlApiMockHentPerson.kt
@@ -33,9 +33,9 @@ private fun WireMockServer.stubPdlApiHentPerson(identitetsnummer: String): WireM
                             {
                                 "data": {
                                     "hentPerson": {
-                                        "bostedsadresse": [
+                                        "folkeregisteridentifikator": [
                                             {
-                                                "coAdressenavn": "Test"
+                                                "identifikasjonsnummer": "$identitetsnummer"
                                             }
                                         ]
                                     }


### PR DESCRIPTION
Da bostedsadresse ikke ligger i behandslingskatalogen og ikke er i bruk i koden, fjerner vi den.