### PR TITLE
Setter cooldown til 0 for å hente teamets eget baseimage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,9 +44,10 @@ updates:
 
   - package-ecosystem: docker
     directory: "/"
+    cooldown:
+      # Setter cooldown til 0 siden denne bare finner avhengigheter fra teamets egne bygg
+      default-days: 0
     schedule:
       interval: daily
-    cooldown:
-      default-days: 7
     registries:
       - ghcr


### PR DESCRIPTION
### Behov / Bakgrunn
Dependabot har endret default til 3 dager, men vi ønsker ikke å vente på baseimage vi har bygd selv

### Løsning
Sett cooldown spesifikt til 0 dager for docker

### Andre endringer

